### PR TITLE
Fix: .NET SDK install was failing with missing dependencies

### DIFF
--- a/RaspberryDebugger/Connection/Connection.cs
+++ b/RaspberryDebugger/Connection/Connection.cs
@@ -591,11 +591,22 @@ namespace RaspberryDebugger.Connection
                          if ! apt-get update ; then
                              exit 1
                          fi
- 
-                         if ! apt-get install -yq libc6 libgcc1 libgssapi-krb5-2 libicu-dev libssl1.1 libstdc++6 zlib1g libgdiplus ; then
-                             exit 1
+                         
+                         debianVersion=$(cat /etc/debian_version)
+                         versionTwelve='12'
+                         if dpkg --compare-versions $debianVersion gt $versionTwelve 
+                         then
+                             # Debian 12 or newer
+                             if ! apt-get install -yq libc6 libgcc-s1 libgssapi-krb5-2 libicu-dev libssl3 libstdc++6 zlib1g libgdiplus ; then
+                                 exit 1
+                             fi
+                         else
+                            # Older than Debian 12
+                            if ! apt-get install -yq libc6 libgcc1 libgssapi-krb5-2 libicu-dev libssl1.1 libstdc++6 zlib1g libgdiplus ; then
+                                exit 1
+                            fi
                          fi
- 
+                         
                          exit 0
                          """;
 

--- a/RaspberryDebugger/Connection/Connection.cs
+++ b/RaspberryDebugger/Connection/Connection.cs
@@ -719,10 +719,16 @@ namespace RaspberryDebugger.Connection
                     // see: https://developercommunity.visualstudio.com/t/VS2022-remote-debugging-over-SSH-does-no/10394545#T-N10410651
                     // This structure is used when Debug->Attach to Process is used. Unfortunately it's tied to
                     // the VS version.
-                    // Currently the VSIX is only targeted to VS2022 so keep the version selector fixed.
-                    // TODO: Use RaspberryDebuggerPackage.VisualStudioVersion for DIR.
+                    // The getvsdbgsh docs suggest that one should use the VS Version to select the proper debugger. I tried
+                    // that as VS2026 has been released. Unfortunately, getvsdbgsh returns an error using "vs2026" as a -v option.
+                    // At least it does at this time anyway. In the process of trying to reverse engineer the valid options for
+                    // -v I noticed that for any version I submitted - vs2019/vs2022/vs2017/latest, the script always attempted
+                    // to download the latest revision of vsdbg. So I'm just going to use latest until that decides to stop working.
+                    // It's going to be installed in the dir associated with the VS version though, keeping the paradigm suggested
+                    // above.
                     var installCommand =
-                        $"""curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v vs2022 -l {PackageHelper.RemoteDebuggerFolder}""";
+                        //$"""curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v {PackageHelper.VisualStudioVersion} -l {PackageHelper.RemoteDebuggerFolder}""";
+                        $"""curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l {PackageHelper.RemoteDebuggerFolder}""";
 
                     try
                     {

--- a/RaspberryDebugger/PackageHelper.cs
+++ b/RaspberryDebugger/PackageHelper.cs
@@ -46,6 +46,16 @@ using VersionsService = RaspberryDebugger.Web;
 
 namespace RaspberryDebugger
 {
+    enum VisualStudioVersions
+    {
+        Unknown,
+
+        vs2017 = 15,
+        vs2019,
+        vs2022,
+        vs2026
+    }
+
     /// <summary>
     /// Package specific constants.
     /// </summary>
@@ -62,6 +72,30 @@ namespace RaspberryDebugger
         private static readonly string ConnectionsPath;
 
         /// <summary>
+        /// Indicates what VS application is currently running. 
+        /// </summary>
+        private static VisualStudioVersions _visualStudioVersion = VisualStudioVersions.Unknown;
+        public static VisualStudioVersions VisualStudioVersion
+        {
+            get
+            {
+                if ( _visualStudioVersion == VisualStudioVersions.Unknown )
+                {
+                    ThreadHelper.ThrowIfNotOnUIThread();
+
+                    DTE2 dte = (DTE2)Package.GetGlobalService(typeof(SDTE));
+
+                    if (Version.TryParse(dte.Version, out Version result))
+                    {
+                        Enum.TryParse(result.Major.ToString(), out _visualStudioVersion);
+                    }
+                }
+
+                return _visualStudioVersion;
+            }
+        }
+
+        /// <summary>
         /// Directory on the Raspberry Pi where .NET Core SDKs will be installed along with the
         /// <b>vsdbg</b> remote debugger.
         /// </summary>
@@ -74,15 +108,13 @@ namespace RaspberryDebugger
 
         /// <summary>
         /// Directory on the Raspberry Pi where the <b>vsdbg</b> remote debugger will be installed.
-        /// Currently the VSIX is only targeted to VS2022 so keep the version selector fixed.
-        /// TODO: Use RaspberryDebuggerPackage.VisualStudioVersion for DIR..
         /// </summary>
-        public const string RemoteDebuggerFolder = "~/.vs-debugger/vs2022";
+        public static readonly string RemoteDebuggerFolder = $"~/.vs-debugger/{VisualStudioVersion}";
 
         /// <summary>
         /// Path to the <b>vsdbg</b> program on the remote machine.
         /// </summary>
-        public const string RemoteDebuggerPath = RemoteDebuggerFolder + "/vsdbg";
+        public static string RemoteDebuggerPath = RemoteDebuggerFolder + "/vsdbg";
 
         /// <summary>
         /// Returns the root directory on the Raspberry Pi where the folder where 

--- a/RaspberryDebugger/RaspberryDebugger.csproj
+++ b/RaspberryDebugger/RaspberryDebugger.csproj
@@ -46,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>CS0414</NoWarn>
     <LangVersion>latest</LangVersion>
+    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Update the required dependencies for the latest Raspian/Raspberry Pi OS based upon MS docs: https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian?tabs=dotnet10#dependencies

Use script to test for Debian version to maintain previous functionality. As Raspberry Pi apparently has always been Debian based this should be backwards compatible. https://stackoverflow.com/a/75195665